### PR TITLE
QuickDeleteMessages fix for Discord White Update

### DIFF
--- a/plugins/QuickDeleteMessages.plugin.js
+++ b/plugins/QuickDeleteMessages.plugin.js
@@ -90,7 +90,7 @@ global.QuickDeleteMessages = function () {
       shiftKey
     } = event);
     if (element.matches(qualifies) || (element = element.closest(qualifies))) {
-      element = element.closest(".message-1PNnaP");
+      element = element.closest(".da-content");
     } else {
       return;
     }


### PR DESCRIPTION
Fix for the new Discord White Theme update as the quick delete stopped working due to the name change for chat element.