### PR TITLE
change size range from 3,4 to 2,3

### DIFF
--- a/plugins/AvatarHover.plugin.js
+++ b/plugins/AvatarHover.plugin.js
@@ -170,7 +170,7 @@ global.AvatarHover = function () {
       left = boundsWindow.width - size;
     }
     top = size > boundsWindow.height ? (boundsWindow.height - size) / 2 : boundsTarget.bottom + size > boundsWindow.height ? boundsTarget.top - size : boundsTarget.bottom;
-    if ("none" === (imageUrl = (((ref = target.querySelector("img")) != null ? ref.src : void 0) || target.src || getComputedStyle(target).backgroundImage.match(/^url\((["']?)(.+)\1\)$/)[2]).replace(/\?size=\d{3,4}\)?$/, `?size=${size}`))) {
+    if ("none" === (imageUrl = (((ref = target.querySelector("img")) != null ? ref.src : void 0) || target.src || getComputedStyle(target).backgroundImage.match(/^url\((["']?)(.+)\1\)$/)[2]).replace(/\?size=\d{2,3}\)?$/, `?size=${size}`))) {
       return hoverCard.remove();
     }
     Object.assign(hoverCard.style, {


### PR DESCRIPTION
this fixes the bug with the current avatar URL format where it doesn't match with the two digit number for the usual avatar target (typically 80 rather than a 3 to 4 digit number)