### PR TITLE
[Link-Profile-Picture] Fix click doing nothing

### DIFF
--- a/plugins/linkProfilePicture.plugin.js
+++ b/plugins/linkProfilePicture.plugin.js
@@ -1,7 +1,7 @@
 /**
  * @name Link-Profile-Picture
  * @description Lets you click users' avatars on their profile page to view a bigger version in your browser.
- * @version 1.2.2
+ * @version 1.2.3
  * @author square
  * @authorLink https://betterdiscord.app/developer/square
  * @website https://betterdiscord.app/plugin/Link-Profile-Picture
@@ -14,8 +14,15 @@ module.exports = class linkProfilePicture {
     document.addEventListener("click", LinkProfilePicture, true);
     this.stop = document.removeEventListener.bind(document, "click", LinkProfilePicture, true);
     function LinkProfilePicture({ target }) {
-      if (target.classList.contains("avatar-3QF_VA") && target.parentElement.classList.contains("header-S26rhB")) {
-        window.open(target.querySelector("img").src.replace(/(?:\?size=\d{3,4})?$/, "?size=4096"), "_blank");
+      if (target.classList.contains("avatar-3QF_VA")) {
+        if (target.parentElement) {
+          let headerElement = target.parentElement.parentElement;
+          if (headerElement) {
+            if (headerElement.classList.contains("header-S26rhB")) {
+              window.open(target.querySelector("img").src.replace(/(?:\?size=\d{3,4})?$/, "?size=4096"), "_blank");
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Discord introduced an intermediary empty `div` between the avatar and the header elements.
This pull request aims to take that in account.