### PR TITLE
Altered '?' to '&' to unbreak (400) the profile pic links - at least for webp/lossless

### DIFF
--- a/plugins/linkProfilePicture.plugin.js
+++ b/plugins/linkProfilePicture.plugin.js
@@ -16,7 +16,7 @@ module.exports = class linkProfilePicture {
     this.stop = document.removeEventListener.bind(document, "click", LinkProfilePicture, true);
     function LinkProfilePicture({ target }) {
       if (target.classList.contains("avatar-3QF_VA") && target.parentElement?.parentElement?.classList.contains("header-S26rhB")) {
-        window.open(target.querySelector("img").src.replace(/(?:\?size=\d{2,4})?$/, "?size=4096"), "_blank");
+        window.open(target.querySelector("img").src.replace(/(?:\?size=\d{2,4})?$/, "&size=4096"), "_blank");
       }
     }
   }

--- a/plugins/linkProfilePicture.plugin.js
+++ b/plugins/linkProfilePicture.plugin.js
@@ -16,7 +16,17 @@ module.exports = class linkProfilePicture {
     this.stop = document.removeEventListener.bind(document, "click", LinkProfilePicture, true);
     function LinkProfilePicture({ target }) {
       if (target.classList.contains("avatar-3QF_VA") && target.parentElement?.parentElement?.classList.contains("header-S26rhB")) {
-        window.open(target.querySelector("img").src.replace(/(?:\?size=\d{2,4})?$/, "&size=4096"), "_blank");
+        const imgSrc = target.querySelector("img").src;
+		const newSize = "size=4096";
+		let newSrc = imgSrc;
+
+		if (imgSrc.includes("?size=")) {
+			newSrc = imgSrc.replace(/(\?|&)size=\d{2,4}/, `?${newSize}`);
+		} else {
+			newSrc = imgSrc.includes("?") ? `${imgSrc}&${newSize}` : `${imgSrc}?${newSize}`;
+		}
+
+		window.open(newSrc, "_blank");
       }
     }
   }


### PR DESCRIPTION
I noticed I was getting 
![image](https://github.com/Inve1951/BetterDiscordStuff/assets/133152184/5cdf0402-8657-4eef-8656-acf573ca35d5)
400 errors when clicking profiles, due to an erroneous ? vs & - this fixes that, and I assume all other webp lossless profile pics... in testing I clicked on 10 random profiles, the larger copies came up 🤷‍♀️

Current 400 urls:
https://cdn.discordapp.com/avatars/475110314611048461/c6d93eb9df7a1971c0b4e2e740ac956a.webp?quality=lossless?size=4096

Urls fixed by this PR:
https://cdn.discordapp.com/avatars/475110314611048461/c6d93eb9df7a1971c0b4e2e740ac956a.webp?quality=lossless&size=4096